### PR TITLE
Center the sounds

### DIFF
--- a/scenes/TestEnvironment.tscn
+++ b/scenes/TestEnvironment.tscn
@@ -183,10 +183,12 @@ autostart = true
 script = ExtResource( 10 )
 
 [node name="SpeakSound" type="AudioStreamPlayer2D" parent="."]
+position = Vector2( 512, 0 )
 stream = SubResource( 5 )
 script = ExtResource( 11 )
 
 [node name="FinishSound" type="AudioStreamPlayer2D" parent="."]
+position = Vector2( 512, 0 )
 stream = ExtResource( 8 )
 script = ExtResource( 11 )
 [connection signal="example_changed" from="." to="HSplitContainer/BBCodePanel/MarginContainer/VBoxContainer/BBCodeSRC" method="_on_RTLTestingEnvironment_example_changed"]


### PR DESCRIPTION
Hello, this is a great project! It's certainly going to be used by me for plenty, especially the custom effects!

I did have 1 issue with the example, though. Because an AudioStreamPlayer2D is used, the pan of the sound is dependent on the position in the 2D scene. It looks like the node was added, but never really positioned. If you have mono sound, you might not notice, but because (0, 0) is the left side of the screen, I was getting all of the audio out of the left speaker.

I positioned the AudioStreamPlayer2D nodes in the center of the viewport, and they're now playing in the center. I guess this could be positioned to the center of the text area, but I was just trying to get it to sound passable for demo purposes. Here's a pull request with those changes (very minor).